### PR TITLE
Bump version 0.0.3-SNAPSHOT

### DIFF
--- a/kafka-connect-transform-kryptonite-gcp/pom.xml
+++ b/kafka-connect-transform-kryptonite-gcp/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.github.hpgrahsl.kafka.connect</groupId>
     <artifactId>kafka-connect-transform-kryptonite-parent</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-connect-transform-kryptonite-gcp</artifactId>
   <packaging>jar</packaging>

--- a/kryptonite/pom.xml
+++ b/kryptonite/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.github.hpgrahsl.kafka.connect</groupId>
     <artifactId>kafka-connect-transform-kryptonite-parent</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
   </parent>
   <artifactId>kryptonite</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>com.github.hpgrahsl.kafka.connect</groupId>
   <artifactId>kafka-connect-transform-kryptonite-parent</artifactId>
-  <version>0.0.2</version>
+  <version>0.0.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>kafka-connect-transform-kryptonite-parent</name>


### PR DESCRIPTION
## WHAT
Changes the version to 0.0.3-SNAPSHOT

## WHY
Just published v0.0.2 https://github.com/mercari/kafka-connect-transform-kryptonite-gcp/releases/tag/v0.0.2