### PR TITLE
Add dual publishing to Google Artifact Registry (GAR)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,8 +6,11 @@ on:
       - master
 
 jobs:
-  publish:
+  publish-github:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -15,7 +18,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           cache: 'maven'
-      - name: Publish snapshot package
+      - name: Publish snapshot package to GitHub Packages
         run: |
           VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)')
           if [[ ${VERSION} == *SNAPSHOT ]]; then
@@ -24,3 +27,31 @@ jobs:
         env:
           USERNAME: ${{ secrets.USERNAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-gar:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/216572124863/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+          service_account: kryptonite-gha@merpay-dataplatform-jp-prod.iam.gserviceaccount.com
+          token_format: 'access_token'
+      - name: Publish snapshot package to GAR
+        run: |
+          VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)')
+          if [[ ${VERSION} == *SNAPSHOT ]]; then
+            mvn -s ${{ github.workspace }}/.github/workflows/settings.xml -P gar --batch-mode deploy
+          fi
+        env:
+          GAR_ACCESS_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,11 @@ on:
       - "v*"
 
 jobs:
-  publish:
+  publish-github:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -15,7 +18,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           cache: 'maven'
-      - name: Publish package
+      - name: Publish package to GitHub Packages
         run: |
           mvn -s ${{ github.workspace }}/.github/workflows/settings.xml --batch-mode deploy
           rm -rf */target/original-*.jar
@@ -29,3 +32,28 @@ jobs:
           files: "*/target/*.jar"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-gar:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/216572124863/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+          service_account: kryptonite-gha@merpay-dataplatform-jp-prod.iam.gserviceaccount.com
+          token_format: 'access_token'
+      - name: Publish package to GAR
+        run: |
+          mvn -s ${{ github.workspace }}/.github/workflows/settings.xml -P gar --batch-mode deploy
+        env:
+          GAR_ACCESS_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}

--- a/.github/workflows/settings.xml
+++ b/.github/workflows/settings.xml
@@ -26,5 +26,10 @@
       <username>${env.USERNAME}</username>
       <password>${env.GITHUB_TOKEN}</password>
     </server>
+    <server>
+      <id>artifact-registry</id>
+      <username>oauth2accesstoken</username>
+      <password>${env.GAR_ACCESS_TOKEN}</password>
+    </server>
   </servers>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -271,4 +271,20 @@
 
   </build>
 
+  <profiles>
+    <profile>
+      <id>gar</id>
+      <distributionManagement>
+        <repository>
+          <id>artifact-registry</id>
+          <url>https://us-maven.pkg.dev/merpay-dataplatform-jp-prod/maven</url>
+        </repository>
+        <snapshotRepository>
+          <id>artifact-registry</id>
+          <url>https://us-maven.pkg.dev/merpay-dataplatform-jp-prod/maven</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
## WHAT

Add Google Artifact Registry (GAR) as an additional publish target alongside GitHub Packages. Both release and snapshot workflows now publish to GAR in parallel using Workload Identity Federation (WIF).

Changes:
- **pom.xml**: Add Maven profile `gar` with GAR distribution management
- **settings.xml**: Add `artifact-registry` server with OAuth2 credentials
- **release.yaml**: Split into parallel `publish-github` and `publish-gar` jobs
- **publish.yaml**: Split into parallel `publish-github` and `publish-gar` jobs

## WHY

Consumers using GCP Artifact Registry (e.g., `dataplatform-pipelines`) can now resolve kryptonite from GAR without requiring GitHub Packages authentication. This eliminates Coursier rate limiting issues caused by unauthenticated requests to GitHub Packages during SBT dependency resolution.

Related PRs:
- Terraform (WIF + SA setup): https://github.com/kouzoh/microservices-terraform/pull/277693 (merged)
- dataplatform-pipelines (remove GitHub Packages resolver): https://github.com/kouzoh/dataplatform-pipelines/pull/1373