### PR TITLE
chore: bump to Java 17 + Kafka 4.2.0 and align dependency tree

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
       - name: Publish snapshot package to GitHub Packages
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
       - name: Authenticate to Google Cloud

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
       - name: Publish package to GitHub Packages
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
       - name: Authenticate to Google Cloud

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [11, 17, 21]
+        java-version: [17, 21]
 
     steps:
       - uses: actions/checkout@v4

--- a/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/key/gcp/GcpSecretManagerKeyVault.java
+++ b/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/key/gcp/GcpSecretManagerKeyVault.java
@@ -15,11 +15,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@NullMarked
 public class GcpSecretManagerKeyVault extends KeyVault {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GcpSecretManagerKeyVault.class);
@@ -48,9 +49,7 @@ public class GcpSecretManagerKeyVault extends KeyVault {
                 new RemovalListener<String, byte[]>() {
                   @Override
                   public void onRemoval(
-                      @Nullable String s,
-                      byte @Nullable [] bytes,
-                      @NonNull RemovalCause removalCause) {
+                      @Nullable String s, byte @Nullable [] bytes, RemovalCause removalCause) {
                     if (bytes != null) {
                       Arrays.fill(bytes, (byte) 0);
                     }

--- a/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/key/gcp/GcpSecretManagerKeyVault.java
+++ b/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/key/gcp/GcpSecretManagerKeyVault.java
@@ -15,12 +15,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@NullMarked
 public class GcpSecretManagerKeyVault extends KeyVault {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GcpSecretManagerKeyVault.class);

--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,14 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <kafka.version>4.2.0</kafka.version>
-    <jackson.version>2.17.3</jackson.version>
-    <kryo.version>5.4.0</kryo.version>
-    <caffeine.version>3.1.8</caffeine.version>
-    <google.cloud.bom.version>26.66.0</google.cloud.bom.version>
-    <grpc.version>1.67.1</grpc.version>
-    <slf4j.version>2.0.12</slf4j.version>
-    <logback.version>1.5.3</logback.version>
-    <junit.version>5.10.2</junit.version>
+    <jackson.version>2.21.2</jackson.version>
+    <kryo.version>5.6.2</kryo.version>
+    <caffeine.version>3.2.4</caffeine.version>
+    <google.cloud.bom.version>26.79.0</google.cloud.bom.version>
+    <grpc.version>1.76.3</grpc.version>
+    <slf4j.version>2.0.17</slf4j.version>
+    <logback.version>1.5.32</logback.version>
+    <junit.version>5.13.4</junit.version>
     <spotless.version>2.43.0</spotless.version>
     <shade.plugin.version>3.5.2</shade.plugin.version>
     <compiler.plugin.version>3.13.0</compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,11 @@
   </modules>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <kafka.version>3.8.1</kafka.version>
+    <kafka.version>4.2.0</kafka.version>
     <jackson.version>2.17.3</jackson.version>
     <kryo.version>5.4.0</kryo.version>
     <caffeine.version>3.1.8</caffeine.version>


### PR DESCRIPTION
## WHAT

Bump the build target to Java 17 and align every dependency in the
project with the Kafka 4.2 stack (same versions the Strimzi-managed
Kafka image will ship). Also migrate the one place in the codebase
that referenced nullability annotations off the deprecated
Checker-Framework qualifiers (no longer transitively available from
Caffeine 3.2.x) and onto JSpecify.

**`pom.xml` — version bumps:**

| Property | Was | Now | Why |
|---|---|---|---|
| `java.version` | 11 | **17** | Kafka 4.x minimum |
| `kafka.version` | 3.8.1 | **4.2.0** | Matches Strimzi 0.51 image |
| `jackson.version` | 2.17.3 | **2.21.2** | Kafka 4.2 bundles 2.21.2 |
| `junit.version` | 5.10.2 | **5.13.4** | Kafka 4.2 bundles 5.13.x |
| `kryo.version` | 5.4.0 | **5.6.2** | Latest stable 5.x |
| `caffeine.version` | 3.1.8 | **3.2.4** | Latest 3.x (Java 11+) |
| `google.cloud.bom.version` | 26.66.0 | **26.79.0** | Latest |
| `grpc.version` | 1.67.1 | **1.76.3** | Aligns with libraries-bom 26.79.0 |
| `slf4j.version` | 2.0.12 | **2.0.17** | Latest 2.0.x |
| `logback.version` | 1.5.3 | **1.5.32** | Latest 1.5.x (Java 17 compatible) |

**Workflows:**

- `.github/workflows/test.yaml` — Java matrix `[11, 17, 21]` → `[17, 21]` (Kafka 4 dropped Java 11 support).
- `.github/workflows/publish.yaml`, `.github/workflows/release.yaml` — bump runner Java from 11 to 17 so the published artifacts match the new `<java.version>` baseline.

**Source — JSpecify migration in `GcpSecretManagerKeyVault.java`:**

Caffeine 3.2.x dropped its transitive `org.checkerframework:checker-qual` dependency and switched to JSpecify, so the `RemovalListener` implementation no longer compiles against
`org.checkerframework.checker.nullness.qual.{NonNull,Nullable}`. Migrate the one file that referenced them:

```diff
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
...
   public void onRemoval(
-      @Nullable String s,
-      byte @Nullable [] bytes,
-      @NonNull RemovalCause removalCause) {
+      @Nullable String s, byte @Nullable [] bytes, RemovalCause removalCause) {
```

JSpecify is brought in transitively by caffeine, so no new explicit dependency is required. `@NonNull` is dropped on `RemovalCause` because Caffeine's `RemovalListener` interface is already `@NullMarked`, so the parameter is non-null by override.

`<version>` stays at `0.0.11-SNAPSHOT`; the next release tag will be `v0.0.11`.

## WHY

`kouzoh/dataplatform-kubernetes#14946` migrates Kafka Connect to Strimzi 0.51.0 + Confluent Platform 8.2 + Debezium 3.5, which means Kafka 4.2.0 brokers and clients. Kafka 4.x requires Java 17 minimum and is incompatible with the current 3.8.1 client baked into this SMT.

Aligning the rest of the dependency tree (Jackson, JUnit, gRPC, etc.) with the same versions Kafka 4.2 ships means the shaded uber-jar won't pull conflicting copies into the Connect worker classpath.

CDC services that depend on the cipher transform (e.g. `kouzoh-partner-jp` spanner-sec, `merpay-merchant-apply-jp`) will adopt the new image once the Strimzi migration lands; this version of the SMT is what they'll consume.

## Verification

Local `clean verify` on Temurin 17 and Temurin 21:

```
./mvnw -B clean verify -DskipITs
# kryptonite ......................................... SUCCESS
# kafka-connect-transform-kryptonite-gcp ............. SUCCESS
# Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

CI matrix exercises both Java 17 and 21 (`test (17)` and `test (21)` SUCCESS).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
